### PR TITLE
Zen 315 styles warning fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simpleviewinc/keg-components",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:web": "PLATFORM=web RE_PLATFORM=web NODE_ENV=test jest --no-cache --config=./configs/jest.config.js",
     "view:reports": "open reports/coverage/lcov-report/index.html",
     "storybook": "nodemon --watch ./configs --exec 'RE_PLATFORM=web start-storybook -p 60710'",
-    "sb": "nodemon --watch ./configs --exec 'RE_PLATFORM=web start-storybook -p 60710'",
+    "sb": "nodemon --watch ./configs --exec 'RE_PLATFORM=native start-storybook -p 60710'",
     "sb:build": "yarn clean:docs; RE_PLATFORM=web build-storybook -c .storybook -o docs",
     "sb:deploy": "storybook-to-ghpages -e docs --dry-run",
     "sb:web": "RE_PLATFORM=web start-storybook -p 60710",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "peerDependencies": {
     "@expo/vector-icons": "^10.2.0",
-    "@simpleviewinc/re-theme": "1.1.2",
+    "@simpleviewinc/re-theme": "2.0.0",
     "expo": "^36.0.0",
     "expo-font": "^8.0.0",
     "jsutils": "git+https://github.com/lancetipton/jsutils.git",

--- a/src/components/appHeader/appHeader.js
+++ b/src/components/appHeader/appHeader.js
@@ -43,7 +43,7 @@ export const AppHeader = props => {
     <View
       style={theme.join(
         get(headerStyles, ['container']),
-        shadow && get(headerStyles, [ 'container', 'shadow' ]),
+        shadow && get(headerStyles, ['shadow']),
         styles
       )}
     >

--- a/src/components/box/textBox.stories.js
+++ b/src/components/box/textBox.stories.js
@@ -11,7 +11,7 @@ const TextBoxStory = ({ type, useClipboard }) => {
     <StoryWrap style={{ paddingTop: 30 }}>
       <View style={{ flexDirection: 'row' }}>
         <Input
-          style={{ margin: 15 }}
+          style={{ margin: 15, width: 200 }}
           onValueChange={setText}
           placeholder={'Type to fill the box'}
         />

--- a/src/components/image/image.stories.js
+++ b/src/components/image/image.stories.js
@@ -9,7 +9,7 @@ storiesOf('Display | Image', module)
   .add('Image', () => (
     <StoryWrap style={wrapStyles}>
       <Image
-        style={{ width: 320, height: 320 }}
+        styles={{ width: 320, height: 320 }}
         src='https://placegoat.com/320/320'
         alt='A Goat'
       />
@@ -28,7 +28,7 @@ storiesOf('Display | Image', module)
       <StoryWrap style={wrapStyles}>
         <Image
           ref={ref}
-          style={{ width: 500, height: 250 }}
+          styles={{ width: 500, height: 250 }}
           src='https://placegoat.com/500/250'
           alt='Another Goat'
         />
@@ -43,7 +43,7 @@ storiesOf('Display | Image', module)
         target='_blank'
       >
         <Image
-          style={{ width: 500, height: 250 }}
+          styles={{ width: 500, height: 250 }}
           src='https://placegoat.com/500/250'
           alt='Another Goat'
         />

--- a/src/components/indicator/indicator.native.js
+++ b/src/components/indicator/indicator.native.js
@@ -1,12 +1,28 @@
 import React from 'react'
-import { Image } from 'react-native'
+import { ActivityIndicator } from 'react-native'
 import { IndicatorWrapper } from './indicator.wrapper'
+import { View } from 'KegView'
 
-export const Indicator = ({ alt, src, source, style }) => (
-  <IndicatorWrapper
-    alt={alt || 'Loading'}
-    Element={Image}
-    src={src || source}
-    style={style}
-  />
-)
+const Element = ({ style = {}, size, color, ...attrs }) => {
+  return (
+    <View>
+      <ActivityIndicator
+        size={size}
+        color={style.color || color}
+      />
+    </View>
+  )
+}
+
+export const Indicator = ({ alt, size, color, styles, ...props }) => {
+  return (
+    <IndicatorWrapper
+      {...props}
+      alt={alt || 'Loading'}
+      size={[ 'large', 'small' ].includes(size) ? size : 'large'}
+      color={color}
+      Element={Element}
+      styles={styles}
+    />
+  )
+}

--- a/src/components/indicator/indicator.wrapper.js
+++ b/src/components/indicator/indicator.wrapper.js
@@ -1,6 +1,4 @@
 import React from 'react'
-import { indicatorUri } from '../../assets/spinners/moderate'
-import { getImgSrc } from '../../utils'
 import { View } from 'KegView'
 import { useThemePath } from 'KegHooks'
 
@@ -10,11 +8,11 @@ export const IndicatorWrapper = props => {
     Element,
     isWeb,
     resizeMode,
-    src,
-    source,
+    size,
     styles,
     type = 'default',
     themePath,
+    ...elProps
   } = props
 
   const [builtStyles] = useThemePath(themePath || `indicator.${type}`, styles)
@@ -22,10 +20,11 @@ export const IndicatorWrapper = props => {
   return (
     <View style={builtStyles.container}>
       <Element
+        {...elProps}
         alt={alt || 'Loading'}
         style={builtStyles.icon}
+        size={size}
         resizeMode={resizeMode || 'contain'}
-        {...getImgSrc(isWeb, src, source, indicatorUri)}
       />
     </View>
   )

--- a/src/components/loading/loading.js
+++ b/src/components/loading/loading.js
@@ -17,13 +17,17 @@ import { useThemePath } from 'KegHooks'
  *
  */
 const Progress = props => {
-  const { styles, text, loadIndicator } = props
+  const { styles, text, loadIndicator, type, size } = props
   const LoadingIndicator = loadIndicator || Indicator
 
   return (
     <View style={styles.progress}>
       { isValidComponent(LoadingIndicator) ? (
-        <LoadingIndicator styles={styles.indicator} />
+        <LoadingIndicator
+          size={size}
+          styles={styles.indicator}
+          type={type}
+        />
       ) : (
         text && <Text style={styles.text}>{ text }</Text>
       ) }
@@ -47,6 +51,7 @@ export const Loading = props => {
     children,
     text = 'Loading',
     indicator,
+    size,
     styles,
     themePath,
     type = 'default',
@@ -61,6 +66,8 @@ export const Loading = props => {
           styles={builtStyles}
           text={text}
           loadIndicator={indicator}
+          type={type}
+          size={size}
         />
       ) }
     </View>

--- a/src/components/loading/loading.stories.js
+++ b/src/components/loading/loading.stories.js
@@ -2,11 +2,47 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Loading } from '../../'
 import { StoryWrap } from 'StoryWrap'
+import { View } from '../'
 
 const storyStyles = { textAlign: 'center' }
+const viewStyles = {
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-evenly',
+}
 
-storiesOf('Loading', module).add('Default', () => (
-  <StoryWrap style={storyStyles}>
-    <Loading text={'Loading'} />
-  </StoryWrap>
-))
+storiesOf('Loading', module)
+  .add('Default', () => (
+    <StoryWrap style={storyStyles}>
+      <View style={viewStyles}>
+        <Loading />
+        <Loading type={'primary'} />
+        <Loading type={'secondary'} />
+        <Loading type={'warn'} />
+        <Loading type={'danger'} />
+      </View>
+    </StoryWrap>
+  ))
+  .add('Small', () => (
+    <StoryWrap style={storyStyles}>
+      <View style={viewStyles}>
+        <Loading size={'small'} />
+        <Loading
+          size={'small'}
+          type={'primary'}
+        />
+        <Loading
+          size={'small'}
+          type={'secondary'}
+        />
+        <Loading
+          size={'small'}
+          type={'warn'}
+        />
+        <Loading
+          size={'small'}
+          type={'danger'}
+        />
+      </View>
+    </StoryWrap>
+  ))

--- a/src/theme/components/appHeader.js
+++ b/src/theme/components/appHeader.js
@@ -36,15 +36,16 @@ const defaultSideSectionStyle = {
     },
   },
 }
+
 export const appHeader = {
   default: {
+    shadow: {
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.5,
+      shadowRadius: 1,
+    },
     container: {
-      shadow: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.5,
-        shadowRadius: 1,
-      },
       $all: {
         ...flex.justify.center,
         ...flex.align.left,

--- a/src/theme/components/appHeader.js
+++ b/src/theme/components/appHeader.js
@@ -39,23 +39,16 @@ const defaultSideSectionStyle = {
 export const appHeader = {
   default: {
     container: {
-      $native: {
+      shadow: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.5,
+        shadowRadius: 1,
+      },
+      $all: {
         ...flex.justify.center,
         ...flex.align.left,
         flex: 0,
-        shadow: {
-          shadowColor: '#000',
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.5,
-          shadowRadius: 1,
-        },
-      },
-      $web: {
-        shadow: {
-          boxShadow: '0px 4px 7px 0px #9E9E9E',
-        },
-      },
-      $all: {
         backgroundColor: get(colors, 'surface.primary.colors.dark'),
         height: 70,
         width: '100%',

--- a/src/theme/components/button/contained.js
+++ b/src/theme/components/button/contained.js
@@ -16,13 +16,10 @@ const containedStyles = (state, colorType) => {
         backgroundColor: activeColor,
         padding: 9,
         minHeight: 35,
-        textAlign: 'center',
         opacity,
       },
       $web: {
         cursor: state === 'disabled' ? 'not-allowed' : 'pointer',
-        pointerEvents: state === 'disabled' && 'not-allowed',
-        outline: 'none',
         boxShadow: 'none',
         ...transition([ 'backgroundColor', 'borderColor' ], 0.3),
       },

--- a/src/theme/components/card/contained.js
+++ b/src/theme/components/card/contained.js
@@ -53,7 +53,6 @@ export const contained = {
   },
   divider: {
     marginBottom: margin.size,
-    hairlineWidth: 1,
   },
   media: {
     container: {

--- a/src/theme/components/indicator.js
+++ b/src/theme/components/indicator.js
@@ -1,17 +1,44 @@
+import { colors } from '../colors'
+import { get } from 'jsutils'
+
+const container = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: 36,
+  minWidth: 36,
+  position: 'relative',
+}
+
 export const indicator = {
   default: {
-    container: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      height: 230,
-      width: 230,
-      position: 'relative',
-    },
+    container,
     icon: {
-      $all: {},
-      $web: {},
-      $native: {},
+      color: get(colors, 'surface.default.colors.main'),
+    },
+  },
+  primary: {
+    container,
+    icon: {
+      color: get(colors, 'surface.primary.colors.main'),
+    },
+  },
+  secondary: {
+    container,
+    icon: {
+      color: get(colors, 'surface.secondary.colors.main'),
+    },
+  },
+  warn: {
+    container,
+    icon: {
+      color: get(colors, 'surface.warn.colors.main'),
+    },
+  },
+  danger: {
+    container,
+    icon: {
+      color: get(colors, 'surface.danger.colors.main'),
     },
   },
 }

--- a/src/theme/components/link.js
+++ b/src/theme/components/link.js
@@ -4,19 +4,14 @@ export const link = {
   default: {
     $all: {
       color: colors.palette.blue01,
-    },
-    $native: {
       textDecorationLine: 'underline',
       textDecorationColor: colors.palette.blue02,
     },
-    $web: {
-      textDecoration: 'underline',
-      cursor: 'pointer',
-    },
   },
   hover: {
-    $web: {
+    $all: {
       color: colors.palette.blue02,
+      textDecorationColor: colors.palette.blue02,
     },
   },
 }

--- a/src/theme/form/checkbox.js
+++ b/src/theme/form/checkbox.js
@@ -13,9 +13,10 @@ const checkboxDefault = {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
+    },
+    $web: {
       display: 'flex',
     },
-    $web: {},
   },
   wrapper: {
     $web: {

--- a/src/theme/form/checkbox.js
+++ b/src/theme/form/checkbox.js
@@ -13,10 +13,9 @@ const checkboxDefault = {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-    },
-    $web: {
       display: 'flex',
     },
+    $web: {},
   },
   wrapper: {
     $web: {

--- a/src/theme/form/input.js
+++ b/src/theme/form/input.js
@@ -1,4 +1,3 @@
-import { typography } from '../typography'
 import { sharedForm } from './sharedForm'
 
 export const input = {
@@ -8,9 +7,7 @@ export const input = {
       ...sharedForm.inputs,
     },
     $web: {
-      outline: 'none',
-      boxSizing: 'border-box',
-      ...typography.font.family,
+      width: '100%',
     },
     $native: {
       width: '100%',

--- a/src/theme/form/select.js
+++ b/src/theme/form/select.js
@@ -1,4 +1,3 @@
-import { typography } from '../typography'
 import { sharedForm } from './sharedForm'
 
 export const select = {
@@ -6,14 +5,6 @@ export const select = {
     $all: {
       ...sharedForm.border,
       ...sharedForm.inputs,
-    },
-    $web: {
-      ...typography.font.family,
-      outline: 'none',
-      boxSizing: 'border-box',
-    },
-    $native: {
-      width: '100%',
     },
   },
 }

--- a/src/theme/form/sharedForm.js
+++ b/src/theme/form/sharedForm.js
@@ -10,7 +10,6 @@ export const sharedForm = {
     overflow: 'hidden',
     height: get(defaults, 'form.input.height', 35),
     padding: padding.size / 2,
-    fontSize: 14,
   },
   border: {
     borderRadius: 5,

--- a/src/theme/form/sharedToggle.js
+++ b/src/theme/form/sharedToggle.js
@@ -19,9 +19,6 @@ export const sharedToggle = {
       alignItems: 'center',
       height: height + space,
     },
-    $web: {
-      outline: 'none',
-    },
   },
   left: {
     marginRight: margin.size,

--- a/src/theme/form/switch.js
+++ b/src/theme/form/switch.js
@@ -14,21 +14,11 @@ const switchDefault = {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-    },
-    $web: {
       display: 'flex',
     },
   },
   wrapper: {
-    $web: {
-      outline: 'none',
-      height: height,
-      width: width * 2,
-      display: 'flex',
-      alignItems: 'stretch',
-      position: 'relative',
-    },
-    $native: {
+    $all: {
       alignItems: 'center',
     },
   },


### PR DESCRIPTION
**Ticket**: [ZEN-315](https://jira.simpleviewtools.com/login.jsp?permissionViolation=true&os_destination=%2Fbrowse%2Fzen-315&page_caps=&user_role=)

## Context

* using keg-components in core or the tap was throwing many warnings in the console
* this was because we are now using the native build (which uses react-native-web), but the retheme platfrom is still `web`, therefore web styles were being passed to react-native primitives that do not accept them

## Goal

* update the styles of the components to use only styling compatible with react-native-web
* update the `yarn sb` command to start the native server instead of web, since we will be using the native build for the time being

## Updates

* `package.json`
  * updated the `yarn sb` command to start storybook with native instead of web elements
* `src/components/appHeader/appHeader.js`
  * updated how appHeader finds the shadow styling
*  `src/components/box/textBox.stories.js`
  * just updated the width of the input element in this storybook file so that the textbox example has more space
* `src/theme/**/*`
  * removed web styles, which were causing issues

## Testing

### Core
* `keg dpg run --package docker.pkg.github.com/simpleviewinc/keg-packages/keg-core:zen-315-styles-warning-fix`
  * this will start up a docker container running keg-core, with these keg-components changes, and it includes other keg- components being rendered in the root of the core
* navigate to http://core.kegdev.xyz
* verify that the app renders and that no warnings appear in the console

### Storybook
* `keg dpg run --package docker.pkg.github.com/simpleviewinc/keg-packages/keg-components:zen-315-styles-warning-fix --command sb:native`
* verify that the storybook stories render as expected

## Notes
* I reviewed every component in `keg-components`, and I found a few that have issues that predate this PR:
  * checkbox is not visible (on env=native)
  * image is not visible (on env=native)
  * link appears, but the color and hover colors do not work (on env=native)
  * loading is not visible (env=native)
* I don't know when these were broken, or if they ever worked to begin with (the PWA proof of concept was web-only)
* I didn't try to fix them, as it wasn't in the scope of this ticket


